### PR TITLE
Improved sorting structure and prepared for release 0.1.2

### DIFF
--- a/llama_cpp/benchmark/sort_benchmark/sort_benchmark.cpp
+++ b/llama_cpp/benchmark/sort_benchmark/sort_benchmark.cpp
@@ -104,11 +104,11 @@ private:
     int input;
 };
 namespace llama {
-    template<>
-    double SortObject<CustomisedClass>::getValue() const {
-        return (double) (obj.getInput());
-    }
+template<>
+int SortObject<CustomisedClass>::compare(SortObject<CustomisedClass> comparedObject) const {
+    return obj.getInput() - comparedObject.getObj().getInput();
 }
+}  // namespace llama
 
 static void BFSortClass(benchmark::State& state) {
     llama::BruteForceSort<CustomisedClass> bfSort = llama::BruteForceSort<CustomisedClass>();

--- a/llama_cpp/example/sort_test/sort_test.cpp
+++ b/llama_cpp/example/sort_test/sort_test.cpp
@@ -42,8 +42,8 @@ class CustomisedClass {
 
 namespace llama {
 template<>
-double SortObject<CustomisedClass>::getValue() const {
-    return static_cast<double>(obj.getInput());
+int SortObject<CustomisedClass>::compare(SortObject<CustomisedClass> comparedObject) const {
+    return obj.getInput() - comparedObject.getObj().getInput();
 }
 }  // namespace llama
 

--- a/llama_cpp/src/Sort/Sort.h
+++ b/llama_cpp/src/Sort/Sort.h
@@ -44,7 +44,7 @@ class SortObject {
     int compare(SortObject<T> comparedObject) const {
         return obj - comparedObject.getObj();
     }
-    
+
     T getObj() { return obj; }
 
     bool operator > (const SortObject<T>& s) const { return compare(s) > 0; }

--- a/llama_cpp/src/Sort/Sort.h
+++ b/llama_cpp/src/Sort/Sort.h
@@ -41,28 +41,31 @@ class SortObject {
         na = true;
     }
 
-    double getValue() const;
-
+    int compare(SortObject<T> comparedObject) const {
+        return obj - comparedObject.getObj();
+    }
+    
     T getObj() { return obj; }
 
-    bool operator > (const SortObject<T>& s) const { return getValue() > s.getValue(); }
-    bool operator < (const SortObject<T>& s) const { return getValue() < s.getValue(); }
-    bool operator >= (const SortObject<T>& s) const { return getValue() >= s.getValue(); }
-    bool operator <= (const SortObject<T>& s) const { return getValue() <= s.getValue(); }
+    bool operator > (const SortObject<T>& s) const { return compare(s) > 0; }
+    bool operator < (const SortObject<T>& s) const { return compare(s) < 0; }
+    bool operator >= (const SortObject<T>& s) const { return compare(s) >= 0; }
+    bool operator <= (const SortObject<T>& s) const { return compare(s) <= 0; }
+    bool operator == (const SortObject<T>& s) const { return compare(s) == 0; }
 
  private:
     T obj;
 };
 
-// Template specializations for SortObject class.
-template<> double SortObject<int>::getValue() const {
-    return static_cast<double>(obj);
-}
-template<> double SortObject<std::string>::getValue() const {
-    return obj.size() > 0 ? static_cast<double>(obj[0]) : 0;
-}
-template<> double SortObject<double>::getValue() const {
-    return obj;
+template<>
+int SortObject<std::string>::compare(SortObject<std::string> comparedObject) const {
+    if (obj.size() > 0 && comparedObject.getObj().size() > 0) {
+        return obj[0] - comparedObject.getObj()[0];
+    } else if (obj.size() > 0) {
+        return 1;
+    } else {
+        return -1;
+    }
 }
 
 // Sort class


### PR DESCRIPTION
Now use compare.
## API Change

`double SortObject<T>::getValue()` Removed
Use `int SortObject<T>::compare(SortObject<T> comparedObject)` now

Benchmark before:

```
Run on (4 X 1000 MHz CPU s)
2016-08-09 23:46:38
Benchmark              Time           CPU Iterations
----------------------------------------------------
StdSortInt            46 ns         45 ns   13891094
StdSortString        298 ns        295 ns    2341952
BFSortInt           3455 ns       3440 ns     206736
BFSortString        6677 ns       6642 ns     114383
BFSortDouble        5584 ns       5500 ns     185540
BFSortClass         5611 ns       5577 ns     121705
InSortInt           3453 ns       3452 ns     196153
InSortString        5777 ns       5754 ns     120550
InSortDouble        2459 ns       2444 ns     250562
InSortClass         2336 ns       2332 ns     304580
```

Benchmark after:

```
Run on (4 X 1000 MHz CPU s)
2016-08-09 23:49:07
Benchmark              Time           CPU Iterations
----------------------------------------------------
StdSortInt            42 ns         42 ns   15843664
StdSortString        290 ns        289 ns    2331911
BFSortInt           3528 ns       3517 ns     201399
BFSortString        6571 ns       6552 ns      90368
BFSortDouble        3549 ns       3546 ns     208154
BFSortClass         3586 ns       3577 ns     186033
InSortInt           2331 ns       2325 ns     302100
InSortString        4054 ns       4041 ns     171444
InSortDouble        2303 ns       2301 ns     301358
InSortClass         2230 ns       2227 ns     330669
```
